### PR TITLE
ST-3840 Upgraded actions in Github workflows

### DIFF
--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: "Set up Java"
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: "corretto"
           java-version: "17"


### PR DESCRIPTION
As the title indicates, this PR is to update any outdated actions in the Github workflows that are currently in use.

actions/checkout@v4 -> ( no change ([4.1.1](https://github.com/actions/checkout)) )
actions/setup-java@v3 -> [actions/setup-java@v4](https://github.com/actions/setup-java)