### PR TITLE
Fix settlement process

### DIFF
--- a/src/main/npl-1.0/processes/demo.npl
+++ b/src/main/npl-1.0/processes/demo.npl
@@ -15,5 +15,5 @@ function demoSettle() -> {
     var car = Car[bob]("VW Beetle", Color.Red);
     var iou = Iou[bob, alice](5000);
 
-    Settle[alice, bob](iou, car).swap[alice, bob]();
+    Settle[alice, bob](iou, car).swap[bob]();
 };

--- a/src/main/npl-1.0/processes/demo.npl
+++ b/src/main/npl-1.0/processes/demo.npl
@@ -15,5 +15,5 @@ function demoSettle() -> {
     var car = Car[bob]("VW Beetle", Color.Red);
     var iou = Iou[bob, alice](5000);
 
-    Settle[alice, bob](iou, car);
+    Settle[alice, bob](iou, car).swap[alice, bob]();
 };

--- a/src/main/npl-1.0/processes/settle.npl
+++ b/src/main/npl-1.0/processes/settle.npl
@@ -6,7 +6,7 @@ use objects.iou.Iou
 @api
 protocol[iouOwner, carOwner] Settle(var iou: Iou, var car: Car) {
     @api
-    permission[iouOwner | carOwner] swap() {
+    permission[iouOwner & carOwner] swap() {
         // Transfer logic.
         iou.forgive[iouOwner]();
         car.transfer[carOwner, iouOwner]();

--- a/src/main/npl-1.0/processes/settle.npl
+++ b/src/main/npl-1.0/processes/settle.npl
@@ -6,7 +6,7 @@ use objects.iou.Iou
 @api
 protocol[iouOwner, carOwner] Settle(var iou: Iou, var car: Car) {
     @api
-    permission[iouOwner & carOwner] swap() {
+    permission[carOwner] swap() {
         // Transfer logic.
         iou.forgive[iouOwner]();
         car.transfer[carOwner, iouOwner]();


### PR DESCRIPTION
1. Shouldn't the `swap` within the settlement protocol only be callable by the car owner, or by both parties?
2. Is there a reason why we just instantiate a `Settle` protocol without performing the `swap` in the demo?

I've created a PR to fix the two points above.  I've set `swap` to be callable by both parties, so I can leave changing it to a single party as an exercise for the Getting Started tutorial I'm creating.